### PR TITLE
Specify version for aidl_interface

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -7,7 +7,7 @@ cc_binary {
     shared_libs: [
         "libbase",
         "libbinder_ndk",
-        "android.hardware.light-ndk_platform",
+        "android.hardware.light-V1-ndk_platform",
     ],
     srcs: [
         "Lights.cpp",


### PR DESCRIPTION
Hello, 
It has been decided to specify the version for aidl_interface in Android-12 (android-12.0.0_r1 .. android-12.0.0_r27)
"android.hardware.light-ndk_platform" has become "android.hardware.light-V1-ndk_platform"

Please see : https://android.googlesource.com/platform//hardware/interfaces/+/38533915d11f3a9d7fed45dab2bef376c1026d47

Note that it has also been decided to remove ndk_platform backend in branch master.
Please see: https://android.googlesource.com/platform//hardware/interfaces/+/27f77fefd71e486e72c9dc4150dc316de13a9153 
