### PR TITLE
manifest: set hal version to 2

### DIFF
--- a/android.hardware.lights.xml
+++ b/android.hardware.lights.xml
@@ -1,6 +1,7 @@
 <manifest version="1.0" type="device">
     <hal format="aidl">
         <name>android.hardware.light</name>
+        <version>2</version>
         <fqname>ILights/default</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
When the device manifest target-level is to 7 (Android 13), the compatibility matrix expect light HAL version set to 2.

Otherwise we have the following errors:
```
The following HALs in device manifest are not declared in FCM <= level 7:
  android.hardware.light.ILights/default (@1)
ERROR: files are incompatible: The following instances are in the device manifest but not specified in framework compatibility matrix:
    android.hardware.light.ILights/default (@1)
```